### PR TITLE
Added Design Decisions and Audit Guide Documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Filesystem artifacts
+.DS_STORE

--- a/docs/auditguide.ipynb
+++ b/docs/auditguide.ipynb
@@ -1,0 +1,24 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Placeholder\n",
+    "\n",
+    "This document will address Issue [#24](https://github.com/ContiNube/CAML/issues/24) and will serve the following purposes:\n",
+    "\n",
+    "- Provide a guide to an auditor who wishes to interpret the results of the metrics to understand the scope of the metric intent and provide boundaries for what is and is not intended to be demonstrated by those metrics\n",
+    "- Provide a simple example of dashboards which could be generated from the metrics to provide observability to a product team wishing to track their system compliance"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/designDecisions.md
+++ b/docs/designDecisions.md
@@ -1,0 +1,11 @@
+# Design Decisions
+
+While building the CAML application there were several design decisions made which are documented here, along with their rationale.
+
+## Intended use of the Machine-Readable Metrics
+
+Issue:  Is there both yaml and code implementing the policy or is there just yaml which is interpreted by a service which then builds the query to the metrics server?
+
+Conversation held 2022/01/14, recorded in Issue [#31](https://github.com/ContiNube/CAML/issues/31).
+
+The decision is that yaml file is read by an interpreter which builds a query message sent to the measures service.  By using this design we lessen the drift between the source of truth (the yaml file) and the implementation.  This also provides the abstraction of the policy in yaml from the implementation of query building.


### PR DESCRIPTION
This PR adds the following new files:

- `docs/designDecisions.md` - A place for us and future developers to better understand some of the decisions which were intentionally weighed and discussed in developing the application.  This gives an opportunity for consistency in delivery and allows us to refactor or "re-decide" at a future date when conditions change.  This PR should resolve Issue #31 
- `docs/auditguide.ipynb` - A document to serve two purposes (further described in the document itself), to provide guidance to an auditor evaluating what these metrics evidence, and to provide a simple, sample visualization of the metrics.  This PR provides an initial template to move toward resolving Issue #24 , but does not fully resolve it yet.

This PR adds a minor update to the following file:

- `.gitignore` - Added in the .DS_STORE file which comes along with some filesystem conversions.  Let's avoid hitchhikers.

Further Decisions:  We will want to decide what kernel to use for the Audit Guide, whether to use the default Python kernel, a Go kernel (in better alignment with the rest of the code), or something else.  Once we decide on the kernel, the rest of the document content can be pursued.