### PR TITLE
metricFrequency now in ISO8601 duration format. Chrontab examples moved...

### DIFF
--- a/Docker/Dockerfile.caml_dev
+++ b/Docker/Dockerfile.caml_dev
@@ -9,6 +9,7 @@ FROM golang as prepit
 # build a working image by installing git tooling and cloning the repo
 RUN apt-get update
 RUN apt-get install -y git
+RUN apt-get install -y yamllint
 WORKDIR /go/src
 # $gitrepo needs to be passed in as a --build-arg 
 # or set via docker-compose.caml_dev.yaml
@@ -25,11 +26,25 @@ RUN git clone $gitrepo
 # TODO: explore gitlens extention 
 # TODO: explore ensuring CLI git is configured automatically. because git is installed as per the above it works but you'll be forced to put your authorization token into the container which is not recommended. Better to just use the vscode model if thats an option.
 
-FROM prepit as buildit 
+FROM prepit as buildit
+
+# CAML toolchain
 WORKDIR /go/src/CAML/src/main
 RUN go mod download
 RUN go mod tidy -compat=1.17 && \
     go get -d -v 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o camldataservice .
 
+# in order to integrate with openmetrics/prometheus 
+# install prometheus node_collector
+# NOTE: node_collector's primary purpose is collecting information about the 'node'/instance. We're not using it for that. Instead we're leveraging https://github.com/prometheus/node_exporter/blob/master/README.md#textfile-collector 
+# TODO: no attempt was made here to keep the resulting image small. that should be done. 
 WORKDIR /go/src
+RUN git clone https://github.com/prometheus/node_exporter
+WORKDIR /go/src/node_exporter
+RUN make
+
+WORKDIR /go/src
+COPY caml_dev_wrapper_script.sh caml_dev_wrapper_script.sh
+RUN ["chmod", "+x", "caml_dev_wrapper_script.sh"]
+CMD ./caml_dev_wrapper_script.sh

--- a/Docker/Dockerfile.grafana
+++ b/Docker/Dockerfile.grafana
@@ -1,0 +1,9 @@
+# this dockerfile configures a simple grafana service
+
+FROM grafana/grafana-oss
+
+# configure to scrape from prometheus (as a datasource)
+COPY grafana_prometheus_datasource.yml /etc/grafana/provisioning/datasources/prometheus_datasource.yml
+# configure dashboards
+COPY grafana_csadashboards.yml /etc/grafana/provisioning/dashboards/csadashboards.yml
+COPY grafana_csadashboards.json /etc/grafana/provisioning/dashboards/csadashboards.json

--- a/Docker/Dockerfile.prometheus
+++ b/Docker/Dockerfile.prometheus
@@ -1,0 +1,6 @@
+# this dockerfile configures a simple prometheus service
+
+FROM prom/prometheus
+
+# configure to scrape from caml_dev
+COPY prometheus.yml /etc/prometheus/prometheus.yml

--- a/Docker/caml_dev_wrapper_script.sh
+++ b/Docker/caml_dev_wrapper_script.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# this is a quick and dirty way to have the caml_dev demo up and running as the default state. 
+
+mkdir ./pom
+
+# a simple server exposing metrics on port 9100
+./node_exporter/node_exporter --collector.disable-defaults --collector.textfile --collector.textfile.directory ./pom &
+
+# forever generate metrics data
+# NOTE: every 20 seconds is an order of magnitude faster than the current pull interval
+cd CAML/src/main/
+while true; do ./camldataservice | sed 's/-/_/g' > ../../../pom/caml.metrics.prom ; echo -n "updated at : "; date; sleep 20; done
+
+# some say the script is still running to this day
+exit $?

--- a/Docker/docker-compose.caml_dev.yaml
+++ b/Docker/docker-compose.caml_dev.yaml
@@ -20,6 +20,30 @@ services:
       - ":5433"
       - ":9042"
 
+  # metric TBSD
+  prometheus:
+    # https://prometheus.io/docs/prometheus/latest/installation/
+    image: prom/prometheus
+    container_name: prometheus
+    build:
+      context: .
+      dockerfile: Dockerfile.prometheus
+    ports: 
+    - "9090:9090"
+    # TODO: The Prometheus image uses a volume to store the actual metrics. For production deployments it is highly recommended to use a named volume to ease managing the data on Prometheus upgrades.
+
+
+  grafana: 
+    # https://grafana.com/docs/grafana/latest/installation/docker/
+    # NOTE: When running Grafana main in production, we strongly recommend that you use the grafana/grafana-oss-dev:<version>-<build ID>pre tag.
+    image: grafana/grafana-oss
+    container_name: grafana-oss
+    build:
+      context: .
+      dockerfile: Dockerfile.grafana
+    ports: 
+    - "3000:3000"
+
   # caml_dev is a working development/test environment
   caml_dev:
       # TODO: explore is env_file is the best way to setup CLI git toolchain
@@ -38,6 +62,8 @@ services:
       image: caml_dev
       container_name: caml_dev
       tty: true
+      ports: 
+      - "9100"
 #networks:
 #  default:
 #    external:

--- a/Docker/grafana_csadashboards.json
+++ b/Docker/grafana_csadashboards.json
@@ -1,0 +1,159 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "csacam_AIS_06_M1",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "csacam_AIS_07_M3",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "csacam_AIS_07_M6",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        }
+      ],
+      "title": "Application & Interface Security",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Application & Interface Security",
+  "uid": "EOBIJHP7z",
+  "version": 2,
+  "weekStart": ""
+}

--- a/Docker/grafana_csadashboards.yml
+++ b/Docker/grafana_csadashboards.yml
@@ -1,0 +1,13 @@
+
+# https://grafana.com/tutorials/provision-dashboards-and-data-sources/
+apiVersion: 1
+
+providers:
+  - name: 'csa caml dashboards'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/Docker/grafana_prometheus_datasource.yml
+++ b/Docker/grafana_prometheus_datasource.yml
@@ -1,0 +1,12 @@
+# grafana/provisioning/datasources/prometheus_datasource.yml
+# NOTE: 2s interval is silly. Its handy for testing though. 
+apiVersion: 1
+ 
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    editable: true
+    jsonData:
+      timeInterval: 2s

--- a/Docker/prometheus.yml
+++ b/Docker/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval:     2s
+  evaluation_interval: 2s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+    - targets:
+      - localhost:9090
+    - targets:
+      - caml_dev:9100

--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ GITREPO=http://github.com/yourusername/CAML  docker compose -f Docker/docker-com
 ## Explore!
 
 To help get things going an instance of prometheus and grafana are installed. The way this works is:
-    * that caml_dev does its best to collect (or generate test data) and compute some example metrics
-        * the test data is silly. it creates metrics like every second or two. very silly. but visible. 
-    * the example metrics are placed where node_exporter can make them available to prometheus
-    * prometheus stores the values in a time series database. The UI page for prometheus offers some very simple graph methods and ability to explore. 
-    * grafana provides a much more complete dashboarding. A dashboard for current metrics is automatically provisioned. 
+
+* that caml_dev does its best to collect (or generate test data) and compute some example metrics
+  * the test data is silly. it creates metrics like every second or two. very silly. but visible. 
+* the example metrics are placed where node_exporter can make them available to prometheus
+* prometheus stores the values in a time series database. The UI page for prometheus offers some very simple graph methods and ability to explore. 
+* grafana provides a much more complete dashboarding. A dashboard for current metrics is automatically provisioned. 
 
 ### Join us! Develop a cool feature
 * **Seems best**: use a toolchain like vscode. you can attach to the container and do development that way. vscode can handle most of this for you: in the vscode UI:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,33 @@ GITREPO=http://github.com/yourusername/CAML  docker compose -f Docker/docker-com
 ```
         
 (NOTE: Docker's environment/.env variable behavior is super overloaded. see https://docs.docker.com/compose/compose-file/compose-file-v3/#env_file as a starting point if you have trouble. An environment variable specified on the command line like this should overload whats in the .env file)        
-    
+
+## Explore!
+
+To help get things going an instance of prometheus and grafana are installed. The way this works is:
+    * that caml_dev does its best to collect (or generate test data) and compute some example metrics
+        * the test data is silly. it creates metrics like every second or two. very silly. but visible. 
+    * the example metrics are placed where node_exporter can make them available to prometheus
+    * prometheus stores the values in a time series database. The UI page for prometheus offers some very simple graph methods and ability to explore. 
+    * grafana provides a much more complete dashboarding. A dashboard for current metrics is automatically provisioned. 
+
+### Join us! Develop a cool feature
+* **Seems best**: use a toolchain like vscode. you can attach to the container and do development that way. vscode can handle most of this for you: in the vscode UI:
+  * "attach to running container" (select caml_dev)
+  * "install all" at the vscode prompts for go-outline and gopls 
+  * re-evaluate your security brain: did you really just install all from some random vscode pointed respositories? 
+  * anyway, now you can run and debug main.go w/ breakpoints and stuff 
+  * because this is a cloned git repository vscode can handle all the git operations to commit changes. The first time you try this it will walk you through getting authorization credentials for vscode. 
+* **Simplest test**: Do the build steps shown in Dockerfile.caml_dev to verify build work
+
+```    
+cd /go/src/volume.caml/main
+go mod download
+go mod tidy -compat=1.17 && go get -d -v
+CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o camldataservice .
+```
+* TODO: whatever else you want. Like you could, add to the dockerfile necessary commands to install a debug environment w/in the container etc. Basically do it all manually.
+
 #### OPTIONAL (not recommended): instantiate parts of the cluster manually: 
 
 The compose file references the Docker/Dockerfile.caml_dev which you _could_ also build on its own.
@@ -48,24 +74,6 @@ Or explore directly with:
 docker run -it --rm caml_dev_manual CAML/main/camldataservice
 ```
  
-### Join us! Develop a cool feature
-* **Seems best**: use a toolchain like vscode. you can attach to the container and do development that way. vscode can handle most of this for you: in the vscode UI:
-  * "attach to running container" (select caml_dev)
-  * "install all" at the vscode prompts for go-outline and gopls 
-  * re-evaluate your security brain: did you really just install all from some random vscode pointed respositories? 
-  * anyway, now you can run and debug main.go w/ breakpoints and stuff 
-  * because this is a cloned git repository vscode can handle all the git operations to commit changes. The first time you try this it will walk you through getting authorization credentials for vscode. 
-* **Simplest test**: Do the build steps shown in Dockerfile.caml_dev to verify build work
-
-```    
-cd /go/src/volume.caml/main
-go mod download
-go mod tidy -compat=1.17 && go get -d -v
-CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o camldataservice .
-```
-* TODO: whatever else you want. Like you could, add to the dockerfile necessary commands to install a debug environment w/in the container etc. Basically do it all manually.
-
-
 ## Basic elements of CAML repo
 
 * Continuous Audit Metrics Catalog

--- a/configFiles/globalConfig/metricsModel.yaml
+++ b/configFiles/globalConfig/metricsModel.yaml
@@ -16,7 +16,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 95%
     sloPeriod: 30d
@@ -37,7 +38,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 80%
     sloPeriod: 30d
@@ -57,7 +59,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin:
     sloPeriod: 30d
@@ -77,7 +80,8 @@ metrics:
     measurePeriod: 365d
   metricFormula: '(A/B)*100'
   metricPeriod: 365d
-  metricFrequency: 0 0 1 1 *
+  metricFrequency: 365d
+  metricChrontabExample: 0 0 1 1 *
   metricSLORecommendations:
   - sloRangeMin: 80%
     sloPeriod: 365
@@ -97,7 +101,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 80%
     sloPeriod: 30d
@@ -117,7 +122,8 @@ metrics:
     measurePeriod: 7d
   metricFormula: '(A/B)*100'
   metricPeriod: 7d
-  metricFrequency: 0 0 * * 0
+  metricFrequency: 7d
+  metricChrontabExample: 0 0 * * 0
   metricSLORecommendations:
   - sloRangeMin: 95%
     sloPeriod: 30d
@@ -137,7 +143,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 85%
     sloPeriod: 30d
@@ -157,7 +164,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 90%
     sloPeriod: 30d
@@ -177,7 +185,8 @@ metrics:
     measurePeriod: 1d
   metricFormula: '(A/B)*100'
   metricPeriod: 1d
-  metricFrequency: 0 0 * * *
+  metricFrequency: 1d
+  metricChrontabExample: 0 0 * * *
   metricSLORecommendations:
   - sloRangeMin: 95%
     sloPeriod: 1d
@@ -196,8 +205,8 @@ metrics:
     measureType: calculate
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
-  metricPeriod:
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 99%
     sloPeriod: 30d
@@ -217,7 +226,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 99%
     sloPeriod: 30d
@@ -237,7 +247,8 @@ metrics:
     measurePeriod: 15d
   metricFormula: '(A/B)*100'
   metricPeriod: 15d
-  metricFrequency: 0 0 1,15 * *
+  metricFrequency: 15d
+  metricChrontabExample: 0 0 1,15 * *
   metricSLORecommendations:
   - sloRangeMin: 80%
     sloPeriod: 15d
@@ -257,7 +268,8 @@ metrics:
     measurePeriod: 15d
   metricFormula: '(A/B)*100'
   metricPeriod: 15d
-  metricFrequency: 0 0 1,15 * *
+  metricFrequency: 15d
+  metricChrontabExample: 0 0 1,15 * *
   metricSLORecommendations:
   - sloRangeMin: 80%
     sloPeriod: 15d
@@ -277,7 +289,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 90%
     sloPeriod: 30d
@@ -297,7 +310,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 99%
     sloPeriod: 30d
@@ -317,7 +331,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 95%
     sloPeriod: 30d
@@ -337,7 +352,8 @@ metrics:
     measurePeriod: 1d
   metricFormula: '((1-(A/B))*100'
   metricPeriod: 1d
-  metricFrequency: 0 0 * * *
+  metricFrequency: 1d
+  metricChrontabExample: 0 0 * * *
   metricSLORecommendations:
   - sloRangeMin: 99%
     sloPeriod: 1d
@@ -357,7 +373,8 @@ metrics:
     measurePeriod: 1h
   metricFormula: '(A/B)*100'
   metricPeriod: 1h
-  metricFrequency: 0 * * * *
+  metricFrequency: 1h
+  metricChrontabExample: 0 * * * *
   metricSLORecommendations:
   - sloRangeMin: 99.99%
     sloPeriod: 1h
@@ -377,7 +394,8 @@ metrics:
     measurePeriod: 1d
   metricFormula: '(A/B)*100'
   metricPeriod: 1d
-  metricFrequency: 0 0 * * *
+  metricFrequency: 1d
+  metricChrontabExample: 0 0 * * *
   metricSLORecommendations:
   - sloRangeMin: 99.99%
     sloPeriod: 1d
@@ -397,7 +415,8 @@ metrics:
     measurePeriod: 1d
   metricFormula: '(A/B)*100'
   metricPeriod: 1d
-  metricFrequency: 0 0 * * *
+  metricFrequency: 1d
+  metricChrontabExample: 0 0 * * *
   metricSLORecommendations:
   - sloRangeMin: 95%
     sloPeriod: 1d
@@ -417,7 +436,8 @@ metrics:
     measurePeriod: 1d
   metricFormula: '(A/B)*100'
   metricPeriod: 1d
-  metricFrequency: 0 0 * * *
+  metricFrequency: 1d
+  metricChrontabExample: 0 0 * * *
   metricSLORecommendations:
   - sloRangeMin: 95%
     sloPeriod: 1d
@@ -437,7 +457,8 @@ metrics:
     measurePeriod: 15d
   metricFormula: '(A/B)*100'
   metricPeriod: 15d
-  metricFrequency: 0 0 1,15 * *
+  metricFrequency: 15d
+  metricChrontabExample: 0 0 1,15 * *
   metricSLORecommendations:
   - sloRangeMin: 80%
     sloPeriod: 15d
@@ -457,7 +478,8 @@ metrics:
     measurePeriod: 1d
   metricFormula: '(A/B)*100'
   metricPeriod: 1d
-  metricFrequency: 0 0 * * *
+  metricFrequency: 1d
+  metricChrontabExample: 0 0 * * *
   metricSLORecommendations:
   - sloRangeMin: 99%
     sloPeriod: 1d
@@ -477,7 +499,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 90%
     sloPeriod: 30d
@@ -497,7 +520,8 @@ metrics:
     measurePeriod: 7d
   metricFormula: '(A/B)*100'
   metricPeriod: 7d
-  metricFrequency: 0 0 * * 0
+  metricFrequency: 7d
+  metricChrontabExample: 0 0 * * 0
   metricSLORecommendations:
   - sloRangeMin: 99%
     sloPeriod: 7d
@@ -511,7 +535,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: 'A*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin:
     sloPeriod: 30d
@@ -531,7 +556,8 @@ metrics:
     measurePeriod: 15d
   metricFormula: '(A/B)*100'
   metricPeriod: 15d
-  metricFrequency: 0 0 1,15 * *
+  metricFrequency: 15d
+  metricChrontabExample: 0 0 1,15 * *
   metricSLORecommendations:
   - sloRangeMin: 99.9%
     sloPeriod: 15d
@@ -551,7 +577,8 @@ metrics:
     measurePeriod: 1d
   metricFormula: '(A/B)*100'
   metricPeriod: 1d
-  metricFrequency: 0 0 1,15 * *
+  metricFrequency: 1d
+  metricChrontabExample: 0 0 1,15 * *
   metricSLORecommendations:
   - sloRangeMin: 99%
     sloPeriod: 1d
@@ -571,7 +598,8 @@ metrics:
     measurePeriod: 7d
   metricFormula: '(A/B)*100'
   metricPeriod: 7d
-  metricFrequency: 0 0 * * 0
+  metricFrequency: 7d
+  metricChrontabExample: 0 0 * * 0
   metricSLORecommendations:
   - sloRangeMin: 99%
     sloPeriod: 7d
@@ -591,7 +619,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 99%
     sloPeriod: 30d
@@ -611,7 +640,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin:
     sloPeriod: 30d
@@ -631,7 +661,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 95%
     sloPeriod: 30d
@@ -650,8 +681,9 @@ metrics:
     measureType: calculate
     measurePeriod: 1d
   metricFormula: '(A/B)*100'
-  metricPeriod:
-  metricFrequency: 0 0 * * *
+  metricPeriod: 1d
+  metricFrequency: 1d
+  metricChrontabExample: 0 0 * * *
   metricSLORecommendations:
   - sloRangeMin: 99%
     sloPeriod: 1d
@@ -671,7 +703,8 @@ metrics:
     measurePeriod: 30d
   metricFormula: '(A/B)*100'
   metricPeriod: 30d
-  metricFrequency: 0 5 */30 * *
+  metricFrequency: 30d
+  metricChrontabExample: 0 5 */1 * *
   metricSLORecommendations:
   - sloRangeMin: 99%
     sloPeriod: 30d

--- a/docs/designDecisions.md
+++ b/docs/designDecisions.md
@@ -9,3 +9,14 @@ Issue:  Is there both yaml and code implementing the policy or is there just yam
 Conversation held 2022/01/14, recorded in Issue [#31](https://github.com/ContiNube/CAML/issues/31).
 
 The decision is that yaml file is read by an interpreter which builds a query message sent to the measures service.  By using this design we lessen the drift between the source of truth (the yaml file) and the implementation.  This also provides the abstraction of the policy in yaml from the implementation of query building.
+
+## Output openmetric/prometheus metric data
+
+Conversation held 2022/03/11, as related to Issue [#24]
+(https://github.com/ContiNube/CAML/issues/24).
+
+A working 'MVP' solution being critical to user engagement and ongoing improvements we need an (example) operational stack that goes from the .yaml file to a demonstratable metric output by a user. This isn't the only possible stack, but its a stack. 
+
+To this end we provide an openmetric/prometheus formatted output from the CAML toolchain.  
+An 'off the shelf' open source demonstration toolchain injesting, and then providing dashboard display is included & configured as part of the distribution. The stack includes node_exporter in the caml_dev container, and provisioned (pre-configured) prometheus & grafana containers. Each has a web interface that can be viewed to explore the metrics.
+

--- a/src/commonlibs/pomgenerator.go
+++ b/src/commonlibs/pomgenerator.go
@@ -1,0 +1,25 @@
+package commonlibs
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+func GeneratePomMetrics(metricsVO *MetricsVO) (err error) {
+	// fmt.Printf("hello world\n")
+	// fmt.Printf("%+v\n", metricsVO.Metrics)
+	rand.Seed(time.Now().UTC().UnixNano())
+	for i := 0; i < len(metricsVO.Metrics); i++ {
+		a := 950 + (rand.Intn(100) - 50)
+		b := 1000 + (rand.Intn(10) - 5)
+		fmt.Println("csacam_"+metricsVO.Metrics[i].MetricID+
+			" {authorization_boundary=\"foo\"} ", int(100*(float32(a)/float32(b))))
+		fmt.Println("csacam_"+metricsVO.Metrics[i].MetricID+"_measureA"+
+			" {authorization_boundary=\"foo\"} ", a)
+		fmt.Println("csacam_"+metricsVO.Metrics[i].MetricID+"_measureB"+
+			" {authorization_boundary=\"foo\"} ", b)
+	}
+
+	return
+}

--- a/src/commonlibs/utilityMethods.go
+++ b/src/commonlibs/utilityMethods.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+
+	"github.com/go-yaml/yaml"
 )
 
 func (controlsVO *ControlsVO) LoadControlsData(fileName string, fileType string) (err error) {
@@ -39,9 +41,11 @@ func (metricsVO *MetricsVO) LoadMetricsData(fileName string, fileType string) (e
 			return fmt.Errorf("cannot unmarshal json file: %s", err)
 		}
 	case "yaml":
+		if err = yaml.Unmarshal(fileByteArray, metricsVO); err != nil {
+			return fmt.Errorf("cannot unmarshal yaml file: %s", err)
+		}
 	default:
 		return fmt.Errorf("specify a valid file type")
-
 	}
 	return nil
 }

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -10,7 +10,8 @@ var metricsVO *libs.MetricsVO
 
 func main() {
 
-	libs.GenerateSampleData()
+	//libs.GenerateSampleData()
+	libs.GeneratePomMetrics(metricsVO)
 	// libs.LoadFileData()
 	// libs.DataDemo()
 
@@ -24,8 +25,8 @@ func init() {
 	}
 
 	metricsVO = new(libs.MetricsVO)
-	metricsFile := "../../configFiles/globalConfig/metrics.json"
-	if err := metricsVO.LoadMetricsData(metricsFile, "json"); err != nil {
+	metricsFile := "../../configFiles/globalConfig/metricsModel.yaml"
+	if err := metricsVO.LoadMetricsData(metricsFile, "yaml"); err != nil {
 		log.Printf("%s", err)
 	}
 


### PR DESCRIPTION
.... moved to metricChrontabExample

This is for issue #44 

Some things to note: 
* I converted 30d chrontab examples from "0 5 */30 * *" to "0 5 */1 * *" to ensure they run in months without 30days. (e.g. run on the 1st of the month rather than the 30th). 
* Across the board we've basically just set each metric frequency to equal the metric period. There are reasons to suspect this is may turn out to be problematic (thanks Willie) -- such as the often noted statement that one should sample at twice the rate of the highest frequency you want to capture (ref:  https://en.wikipedia.org/wiki/Nyquist_rate ). For example, should we sample (e.g. set metricFrequency) to half the metricPeriod? I have not addressed this. 