### PR TITLE
Adding CSA https://github.com/cloudsecurityalliance/continuous-audit-metrics.git and fixing a build issue

### DIFF
--- a/Docker/.env
+++ b/Docker/.env
@@ -1,1 +1,2 @@
-GITREPO=https://github.com/continube/CAML.git
+GITREPOCAML=https://github.com/pritikin/CAML.git
+GITREPOCAM=https://github.com/cloudsecurityalliance/continuous-audit-metrics.git

--- a/Docker/Dockerfile.caml_dev
+++ b/Docker/Dockerfile.caml_dev
@@ -4,18 +4,27 @@
 
 # go being the lingua in question we start with a golang image so 
 # supporting dev work in place is easy
-FROM golang as prepit
+# NOTE: There appears to be a recent problem building node_exporter on the latest golang
+# ref: https://stackoverflow.com/questions/71758856/github-action-for-golangci-lint-fails-with-cant-load-fmt from 9 days ago
+# TODO: determine process for updating to latest w/o risking random failures
+FROM golang:1.17.7 as prepit
 
 # build a working image by installing git tooling and cloning the repo
 RUN apt-get update
 RUN apt-get install -y git
 RUN apt-get install -y yamllint
 WORKDIR /go/src
+
+# $gitrepo is the Continuous Audit Metrics Library repo
 # $gitrepo needs to be passed in as a --build-arg 
 # or set via docker-compose.caml_dev.yaml
-ARG gitrepo
-RUN git clone $gitrepo
+ARG gitrepoCAML
+RUN git clone $gitrepoCAML
 
+# $gitrepocam is the CSA Continuous Audit Metrics repo
+# set this the same way as you set $gitrep
+ARG gitrepoCAM
+RUN git clone $gitrepoCAM
 
 # at this point a developer can attach vscode to the dev image and work with it directly
 # to do so:
@@ -42,7 +51,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o camldataservice .
 WORKDIR /go/src
 RUN git clone https://github.com/prometheus/node_exporter
 WORKDIR /go/src/node_exporter
-RUN make
+# RUN make
 
 WORKDIR /go/src
 COPY caml_dev_wrapper_script.sh caml_dev_wrapper_script.sh

--- a/Docker/Dockerfile.caml_dev
+++ b/Docker/Dockerfile.caml_dev
@@ -51,7 +51,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o camldataservice .
 WORKDIR /go/src
 RUN git clone https://github.com/prometheus/node_exporter
 WORKDIR /go/src/node_exporter
-# RUN make
+RUN make
 
 WORKDIR /go/src
 COPY caml_dev_wrapper_script.sh caml_dev_wrapper_script.sh

--- a/Docker/docker-compose.caml_dev.yaml
+++ b/Docker/docker-compose.caml_dev.yaml
@@ -52,13 +52,16 @@ services:
       build:
         context: .
         dockerfile: Dockerfile.caml_dev
-        # the $GITREPO value is coming from .env located in the same
-        # directory as this yaml file. It will look something like (make it point to your fork): 
+        # the $GITREPOCAML & $GITREPOCAM values are coming from .env 
+        # located in the same directory as this yaml file. It will look 
+        # something like (make it point to your fork): 
         #   prompt% cat Docker/.env
-        #   GITREPO=https://github.com/ContiNube/CAML.git
+        #   GITREPOCAML=https://github.com/ContiNube/CAML.git
+        #   GITREPOCAM=GITREPOCAM=https://github.com/cloudsecurityalliance/continuous-audit-metrics.git
         # TODO: see about explicitly indicating this file instead of depending on the hidden dot file "sideeffect" 
         args:
-          - gitrepo=$GITREPO
+          - gitrepoCAML=$GITREPOCAML
+          - gitrepoCAM=$GITREPOCAM
       image: caml_dev
       container_name: caml_dev
       tty: true


### PR DESCRIPTION
Now the docker image will have a copy of the CSA CAM repository so we can switch the metrics code over to using it. 

Also fixes a build issues with ndoe_exporter. Apparently a problem with the latest golang? I locked the golang version back to the previous working version for stability. 
